### PR TITLE
Php app db support

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessSshDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessSshDriver.java
@@ -818,7 +818,7 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
     public int copyUsingProtocol(String url, String deployTargetDir){
         int result =0;
         if(isHttpsGitURL(url)){
-            log.info("Git. Es una direccion git {} {}", new Object[]{this, url});
+            log.info("Git: it is a git repo {} {}", new Object[]{this, url});
             result = copyUsingProtocolGitHttps(url, deployTargetDir);
         }
         return result;

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppDriver.java
@@ -20,12 +20,11 @@ package brooklyn.entity.webapp;
 
 
 import brooklyn.entity.basic.SoftwareProcessDriver;
+
 import java.util.Set;
 
 
 public interface PhpWebAppDriver extends SoftwareProcessDriver {
-
-
 
     Set<String> getEnabledProtocols();
 
@@ -33,9 +32,7 @@ public interface PhpWebAppDriver extends SoftwareProcessDriver {
 
     Integer getHttpsPort();
 
-
     HttpsSslConfig getHttpsSslConfig();
-
 
     String deployGitResource(String url, String targetName);
 
@@ -44,8 +41,6 @@ public interface PhpWebAppDriver extends SoftwareProcessDriver {
     void undeploy(String targetName);
 
     SourceNameResolver getSourceNameResolver();
-
-
 
 
 }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppService.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppService.java
@@ -20,7 +20,9 @@ package brooklyn.entity.webapp;
 
 import brooklyn.config.ConfigKey;
 import brooklyn.event.basic.BasicConfigKey;
+import brooklyn.event.basic.MapConfigKey;
 import brooklyn.util.flags.SetFromFlag;
+
 import java.util.List;
 
 
@@ -34,12 +36,28 @@ public interface PhpWebAppService extends WebAppService {
     public static final ConfigKey<String> APP_GIT_REPO_URL = new BasicConfigKey<String>(
             String.class, "php.app.git.repo.url ", "The Git repository where the application source code is stored (gitRepo)");
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @SetFromFlag("app_name")
     public static final ConfigKey<String> APP_NAME = new BasicConfigKey(
-            List.class, "php.app.name", "The name of the PHP application");
+            String.class, "php.app.name", "The name of the PHP application");
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @SetFromFlag("app_start_file")
     public static final ConfigKey<List<String>> APP_START_FILE = new BasicConfigKey(
             List.class, "php.app.start.file", "PHP application file to start e.g. main.php, or launch.php");
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SetFromFlag("db_connection_file_config")
+    public static final ConfigKey<String> DB_CONNECTION_FILE_CONFIG = new BasicConfigKey(
+            String.class, "php.db.connection.file.config", "The name of the PHP application");
+
+//    @SuppressWarnings({ "unchecked", "rawtypes" })
+//    @SetFromFlag("db_connection_config_params")
+//    public static final ConfigKey<Map<String,String>> DB_CONNECTION_CONFIG_PARAMS = new BasicConfigKey(
+//            Map.class, "php.db.connection.config.params", "PHP application file to start e.g. main.php, or launch.php");
+
+    @SetFromFlag("db_connection_config_params")
+    public static final MapConfigKey<String> DB_CONNECTION_CONFIG_PARAMS = new MapConfigKey<String>(String.class,
+            "php.db.connection.config.params", "PHP application file to start e.g. main.php, or launch.php");
 
 }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppService.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppService.java
@@ -19,6 +19,8 @@
 package brooklyn.entity.webapp;
 
 import brooklyn.config.ConfigKey;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.entity.basic.SoftwareProcess;
 import brooklyn.event.basic.BasicConfigKey;
 import brooklyn.event.basic.MapConfigKey;
 import brooklyn.util.flags.SetFromFlag;
@@ -59,5 +61,10 @@ public interface PhpWebAppService extends WebAppService {
     @SetFromFlag("db_connection_config_params")
     public static final MapConfigKey<String> DB_CONNECTION_CONFIG_PARAMS = new MapConfigKey<String>(String.class,
             "php.db.connection.config.params", "PHP application file to start e.g. main.php, or launch.php");
+
+
+    @SetFromFlag("php.version")
+    public static final ConfigKey<String> SUGGESTED_PHP_VERSION =
+            ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.5.9");
 
 }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSoftwareProcess.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSoftwareProcess.java
@@ -27,11 +27,12 @@ import brooklyn.entity.basic.SoftwareProcess;
 import brooklyn.entity.proxying.ImplementedBy;
 import brooklyn.event.AttributeSensor;
 import brooklyn.event.basic.BasicAttributeSensor;
+
 import java.util.Set;
 
 
 @ImplementedBy(PhpWebAppSoftwareProcessImpl.class)
-public interface PhpWebAppSoftwareProcess extends SoftwareProcess, PhpWebAppService{
+public interface PhpWebAppSoftwareProcess extends SoftwareProcess, PhpWebAppService {
 
     public static final AttributeSensor<Set<String>> DEPLOYED_PHP_APPS = new BasicAttributeSensor(
             Set.class, "webapp.deployedApps", "Names of archives/contexts that are currently deployed");
@@ -39,36 +40,38 @@ public interface PhpWebAppSoftwareProcess extends SoftwareProcess, PhpWebAppServ
     public static final MethodEffector<Void> DEPLOY_TARBALL_RESOURCE = new MethodEffector<Void>(PhpWebAppSoftwareProcess.class, "deployTarballResource");
     public static final MethodEffector<Void> UNDEPLOY = new MethodEffector<Void>(PhpWebAppSoftwareProcess.class, "undeploy");
 
-    ConfigKey<String> SUGGESTED_VERSION= ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5");
 
     /**
      * It deploys an application which is stored in a git repository.
      * The repo is cloned using the name specified by the targetName.
      * So, the target name is used as id to deploy the application in the server.
-     * @param url A url of the git repo where the application are stored. Currently, https url are supported.
+     *
+     * @param url        A url of the git repo where the application are stored. Currently, https url are supported.
      * @param targetName name of the application used to deploy it.
      */
-    @Effector(description="Deploys the given artifact, from a source URL, to a given deployment filename/context")
+    @Effector(description = "Deploys the given artifact, from a source URL, to a given deployment filename/context")
     public void deployGitResource(
-            @EffectorParam(name="url", description="URL of git Repo file") String url,
-            @EffectorParam(name="targetName", description="Application Name") String targetName);
+            @EffectorParam(name = "url", description = "URL of git Repo file") String url,
+            @EffectorParam(name = "targetName", description = "Application Name") String targetName);
 
     /**
      * It deploys an application which is packaged like a tarball from a url.
      * The application is downloaded and unpackaged in the folder specified by the targetName.
-     * @param url A url of the tarball resource where the application are stored.
+     *
+     * @param url        A url of the tarball resource where the application are stored.
      * @param targetName name of the application used to deploy it.
      */
-    @Effector(description="Deploys the given artifact, from a source URL, to a given deployment filename/context")
+    @Effector(description = "Deploys the given artifact, from a source URL, to a given deployment filename/context")
     public void deployTarballResource(
-            @EffectorParam(name="url", description="URL of tarball resource") String url,
-            @EffectorParam(name="targetName", description="Application Name") String targetName);
+            @EffectorParam(name = "url", description = "URL of tarball resource") String url,
+            @EffectorParam(name = "targetName", description = "Application Name") String targetName);
 
     /**
      * For the DEPLOYED_PHP_APP to be updated, the input must match the result of the call to deploy
      */
-    @Effector(description="Undeploys the given context/artifact")
+    @Effector(description = "Undeploys the given context/artifact")
     public void undeploy(
-            @EffectorParam(name="targetName") String targetName);
+            @EffectorParam(name = "targetName") String targetName);
 
 }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSoftwareProcessImpl.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSoftwareProcessImpl.java
@@ -19,30 +19,32 @@
 package brooklyn.entity.webapp;
 
 import brooklyn.entity.Entity;
-import brooklyn.entity.annotation.Effector;
-import brooklyn.entity.annotation.EffectorParam;
 import brooklyn.entity.basic.SoftwareProcessImpl;
 import brooklyn.util.text.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.LinkedHashMap;
-import java.util.Set;
 import java.util.Map;
+import java.util.Set;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 
-public abstract class PhpWebAppSoftwareProcessImpl extends SoftwareProcessImpl implements PhpWebAppSoftwareProcess{
-    private static final Logger LOG= LoggerFactory.getLogger(PhpWebAppSoftwareProcessImpl.class);
+public abstract class PhpWebAppSoftwareProcessImpl extends SoftwareProcessImpl implements PhpWebAppSoftwareProcess {
+    private static final Logger LOG = LoggerFactory.getLogger(PhpWebAppSoftwareProcessImpl.class);
 
-    public PhpWebAppSoftwareProcessImpl(){ super(); }
-
-    public PhpWebAppSoftwareProcessImpl(Entity parent){
-        this(new LinkedHashMap(),parent);
+    public PhpWebAppSoftwareProcessImpl() {
+        super();
     }
 
-    public PhpWebAppSoftwareProcessImpl(Map flags){
+    public PhpWebAppSoftwareProcessImpl(Entity parent) {
+        this(new LinkedHashMap(), parent);
+    }
+
+    public PhpWebAppSoftwareProcessImpl(Map flags) {
         this(flags, null);
     }
 
@@ -50,7 +52,7 @@ public abstract class PhpWebAppSoftwareProcessImpl extends SoftwareProcessImpl i
         super(flags, parent);
     }
 
-    public PhpWebAppDriver getDriver(){
+    public PhpWebAppDriver getDriver() {
         return (PhpWebAppDriver) super.getDriver();
     }
 
@@ -62,14 +64,17 @@ public abstract class PhpWebAppSoftwareProcessImpl extends SoftwareProcessImpl i
         return getAttribute(DEPLOYED_PHP_APPS);
     }
 
-    protected int getHttpPort(){ return getAttribute(HTTP_PORT);}
+    protected int getHttpPort() {
+        return getAttribute(HTTP_PORT);
+    }
 
-    protected void setDeployedPhpAppsAttribute(Set<String> deployedPhpApps){
+
+    protected void setDeployedPhpAppsAttribute(Set<String> deployedPhpApps) {
         setAttribute(DEPLOYED_PHP_APPS, deployedPhpApps);
     }
 
     @Override
-    protected void connectSensors(){
+    protected void connectSensors() {
         super.connectSensors();
         WebAppServiceMethods.connectWebAppServerPolicies(this);
     }
@@ -86,7 +91,7 @@ public abstract class PhpWebAppSoftwareProcessImpl extends SoftwareProcessImpl i
         super.doStop();
     }
 
-    private void putEnricherValuesToNullValue(){
+    private void putEnricherValuesToNullValue() {
         setAttribute(REQUESTS_PER_SECOND_LAST, 0D);
         setAttribute(REQUESTS_PER_SECOND_IN_WINDOW, 0D);
     }
@@ -99,66 +104,64 @@ public abstract class PhpWebAppSoftwareProcessImpl extends SoftwareProcessImpl i
         deployInitialAppTarballResource();
     }
 
-    private void initDeployAppAttributeIfIsNull(){
+    private void initDeployAppAttributeIfIsNull() {
         if (getDeployedPhpAppsAttribute() == null)
             setDeployedPhpAppsAttribute(Sets.<String>newLinkedHashSet());
     }
 
     private void deployInitialAppGitSource() {
         String gitRepoUrl = getConfig(APP_GIT_REPO_URL);
-        if (gitRepoUrl!=null){
-            String targetName=inferCorrectAppGitName();
+        if (gitRepoUrl != null) {
+            String targetName = inferCorrectAppGitName();
             deployGitResource(gitRepoUrl, targetName);
         }
     }
 
-    private String inferCorrectAppGitName(){
+    private String inferCorrectAppGitName() {
         String result;
-        if(Strings.isEmpty(getConfig(APP_NAME))){
-            result=getDriver().getSourceNameResolver().getNameOfRepositoryGitFromHttpsUrl(getConfig(APP_GIT_REPO_URL));
-        }
-        else{
-            result=getConfig(APP_NAME);
+        if (Strings.isEmpty(getConfig(APP_NAME))) {
+            result = getDriver().getSourceNameResolver().getNameOfRepositoryGitFromHttpsUrl(getConfig(APP_GIT_REPO_URL));
+        } else {
+            result = getConfig(APP_NAME);
         }
         return result;
     }
 
-    private void deployInitialAppTarballResource(){
+    private void deployInitialAppTarballResource() {
         String tarballResourceUrl = getConfig(APP_TARBALL_URL);
-        if (tarballResourceUrl!=null){
-            String targetName=inferCorrectAppTarballName();
+        if (tarballResourceUrl != null) {
+            String targetName = inferCorrectAppTarballName();
             deployTarballResource(tarballResourceUrl, targetName);
         }
     }
 
-    private String  inferCorrectAppTarballName(){
+    private String inferCorrectAppTarballName() {
         String result;
-        if(Strings.isEmpty(getConfig(APP_NAME))){
-            result=getDriver().getSourceNameResolver().getIdOfTarballFromUrl(getConfig(APP_TARBALL_URL));
-        }
-        else{
-            result=getConfig(APP_NAME);
+        if (Strings.isEmpty(getConfig(APP_NAME))) {
+            result = getDriver().getSourceNameResolver().getIdOfTarballFromUrl(getConfig(APP_TARBALL_URL));
+        } else {
+            result = getConfig(APP_NAME);
         }
         return result;
     }
 
-    public void deployGitResource(String url,String targetName) {
+    public void deployGitResource(String url, String targetName) {
         try {
             deployGitPhpApp(url, targetName);
         } catch (RuntimeException e) {
-            LOG.warn("Error deploying '"+url+"' on "+toString()+"; rethrowing...", e);
+            LOG.warn("Error deploying '" + url + "' on " + toString() + "; rethrowing...", e);
             throw Throwables.propagate(e);
         }
     }
 
-    private void deployGitPhpApp(String url, String targetName){
+    private void deployGitPhpApp(String url, String targetName) {
         checkNotNull(url, "url");
-        PhpWebAppDriver driver =   getDriver();
+        PhpWebAppDriver driver = getDriver();
         String deployedAppName = driver.deployGitResource(url, targetName);
         updateDeploymentSensorToDeployAnApp(deployedAppName);
     }
 
-    private void updateDeploymentSensorToDeployAnApp(String deployedAppName){
+    private void updateDeploymentSensorToDeployAnApp(String deployedAppName) {
         Set<String> deployedPhpApps = getDeployedPhpAppsAttribute();
         if (deployedPhpApps == null) {
             deployedPhpApps = Sets.newLinkedHashSet();
@@ -167,46 +170,42 @@ public abstract class PhpWebAppSoftwareProcessImpl extends SoftwareProcessImpl i
         setDeployedPhpAppsAttribute(deployedPhpApps);
     }
 
-    public void deployTarballResource( String url, String targetName){
+    public void deployTarballResource(String url, String targetName) {
         try {
             deployTarballPhpApp(url, targetName);
         } catch (RuntimeException e) {
-            LOG.warn("Error deploying '"+url+"' on "+toString()+"; rethrowing...", e);
+            LOG.warn("Error deploying '" + url + "' on " + toString() + "; rethrowing...", e);
             throw Throwables.propagate(e);
         }
     }
 
-    private void deployTarballPhpApp(String url, String targetName){
+    private void deployTarballPhpApp(String url, String targetName) {
         //TODO deployment git resource
         checkNotNull(url, "url");
-        PhpWebAppDriver driver =   getDriver();
+        PhpWebAppDriver driver = getDriver();
         String deployedAppName = driver.deployTarballResource(url, targetName);
         updateDeploymentSensorToDeployAnApp(deployedAppName);
     }
 
-    /** For the DEPLOYED_PHP_APP to be updated, the input must match the result of the call to deploy */
-    @Override
-    @Effector(description="Undeploys the given context/artifact")
-    public void undeploy(
-            @EffectorParam(name="deployedAppName") String targetName) {
+    public void undeploy(String targetName) {
         try {
-
             undeployPhpApp(targetName);
 
         } catch (RuntimeException e) {
-            LOG.warn("Error undeploying '"+targetName+"' on "+toString()+"; rethrowing...", e);
+            LOG.warn("Error undeploying '" + targetName + "' on " + toString() + "; rethrowing...", e);
             throw Throwables.propagate(e);
         }
     }
-    private void undeployPhpApp(String targetName){
+
+    private void undeployPhpApp(String targetName) {
         PhpWebAppDriver driver = getDriver();
         driver.undeploy(targetName);
         updateDeploymentSensorToUndeployAnApp(targetName);
     }
 
-    private void updateDeploymentSensorToUndeployAnApp(String targetName){
+    private void updateDeploymentSensorToUndeployAnApp(String targetName) {
         initDeployAppAttributeIfIsNull();
-        Set<String> deployedPhpApps=getDeployedPhpAppsAttribute();
+        Set<String> deployedPhpApps = getDeployedPhpAppsAttribute();
         deployedPhpApps.remove(targetName);
         setDeployedPhpAppsAttribute(deployedPhpApps);
     }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSshDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSshDriver.java
@@ -24,15 +24,17 @@ import brooklyn.location.basic.SshMachineLocation;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+
+import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 
-public abstract class PhpWebAppSshDriver extends AbstractSoftwareProcessSshDriver implements PhpWebAppDriver{
+public abstract class PhpWebAppSshDriver extends AbstractSoftwareProcessSshDriver implements PhpWebAppDriver {
 
-    public PhpWebAppSshDriver(PhpWebAppSoftwareProcessImpl entity, SshMachineLocation machine){
+    public PhpWebAppSshDriver(PhpWebAppSoftwareProcessImpl entity, SshMachineLocation machine) {
         super(entity, machine);
     }
 
@@ -84,7 +86,7 @@ public abstract class PhpWebAppSshDriver extends AbstractSoftwareProcessSshDrive
     }
 
     @Override
-    public SourceNameResolver getSourceNameResolver(){
+    public SourceNameResolver getSourceNameResolver() {
         return new SourceNameResolver();
     }
 
@@ -99,62 +101,63 @@ public abstract class PhpWebAppSshDriver extends AbstractSoftwareProcessSshDrive
             checkNotNull(port, "HTTP_PORT sensors not set; is an acceptable port available?");
             return String.format("http://%s:%s/", getHostname(), port);
         } else {
-            throw new IllegalStateException("HTTP and HTTPS protocols not enabled for "+entity+"; enabled protocols are "+getEnabledProtocols());
+            throw new IllegalStateException("HTTP and HTTPS protocols not enabled for " + entity + "; enabled protocols are " + getEnabledProtocols());
         }
     }
 
     @Override
     public void postLaunch() {
         String rootUrl = inferRootUrl();
+        entity.setAttribute(Attributes.MAIN_URI, URI.create(rootUrl));
         entity.setAttribute(WebAppService.ROOT_URL, rootUrl);
     }
 
     protected abstract String getDeploySubdir();
 
     protected String getDeployDir() {
-        if (getDeploySubdir()==null)
-            throw new IllegalStateException("no deployment directory available for "+this);
+        if (getDeploySubdir() == null)
+            throw new IllegalStateException("no deployment directory available for " + this);
         //getRunDir is configured in SoftwareProcess
-        return getRunDir()+"/"+ getDeploySubdir();
+        return getRunDir() + "/" + getDeploySubdir();
     }
 
     @Override
-    public String deployGitResource(String url, String targetName){
+    public String deployGitResource(String url, String targetName) {
         log.info("{} deploying Git Resource{} to {}:{}", new Object[]{entity, url, getHostname()});
-        String deployTargetDir=getDeployDir()+targetName;
+        String deployTargetDir = getDeployDir() + targetName;
         int copyResult = copyUsingProtocol(url, deployTargetDir);
-        if (copyResult!=0)
+        if (copyResult != 0)
             log.warn("Problem deploying {} to {}:{} for {}: result {}", new Object[]{url, getHostname(), deployTargetDir, entity, copyResult});
         return targetName;
     }
 
-    public String deployTarballResource(String url, String targetName){
+    public String deployTarballResource(String url, String targetName) {
         log.info("{} deploying Tarball Resource{} to {}:{}", new Object[]{entity, url, getHostname()});
-        String deployTargetDir=getDeployDir()+targetName+"/";
-        String tarballResourceName=getSourceNameResolver().getTarballResourceNameFromUrl(url);
+        String deployTargetDir = getDeployDir() + targetName + "/";
+        String tarballResourceName = getSourceNameResolver().getTarballResourceNameFromUrl(url);
 
         //Fixme using copyResource. The proxy it is the problem.
         int copyResult = copyResourceFromUrl(url, deployTargetDir, true);
 
-        if (copyResult!=0)
+        if (copyResult != 0)
             log.warn("Problem deploying {} to {}:{} for {}: result {}", new Object[]{url, getHostname(), deployTargetDir, entity, copyResult});
 
-        int extractResult=extractTarballResource(deployTargetDir, tarballResourceName);
+        int extractResult = extractTarballResource(deployTargetDir, tarballResourceName);
 
-        if (extractResult!=0)
+        if (extractResult != 0)
             log.warn("Problem extract {} in {} result {} for {}", new Object[]{tarballResourceName, deployTargetDir, extractResult, entity});
 
         return targetName;
     }
 
-    private int copyResourceFromUrl(String url, String deployTargetDir, boolean createParent){
+    private int copyResourceFromUrl(String url, String deployTargetDir, boolean createParent) {
         if (createParent)
             createParentDir(deployTargetDir);
-        String downloadCommand=String.format("wget -P %s %s",deployTargetDir, url);
+        String downloadCommand = String.format("wget -P %s %s", deployTargetDir, url);
         return getMachine().execCommands("download resource", ImmutableList.of(downloadCommand));
     }
 
-    private void createParentDir(String dir){
+    private void createParentDir(String dir) {
         int lastSlashIndex = dir.lastIndexOf("/");
         String parent = (lastSlashIndex > 0) ? dir.substring(0, lastSlashIndex) : null;
         if (parent != null) {
@@ -162,8 +165,8 @@ public abstract class PhpWebAppSshDriver extends AbstractSoftwareProcessSshDrive
         }
     }
 
-    private int extractTarballResource(String  deployTargetDir, String tarballResourceName){
-        String extractCommand=String.format("tar xzfv %s%s -C %s",deployTargetDir, tarballResourceName, deployTargetDir);
+    private int extractTarballResource(String deployTargetDir, String tarballResourceName) {
+        String extractCommand = String.format("tar xzfv %s%s -C %s", deployTargetDir, tarballResourceName, deployTargetDir);
         return getMachine().execCommands("extract tarball resource", ImmutableList.of(extractCommand));
     }
 
@@ -178,11 +181,11 @@ public abstract class PhpWebAppSshDriver extends AbstractSoftwareProcessSshDrive
 //                .body.append(commands)
 //                .execute();
         int resultOfCommand = getMachine().execCommands("install php", ImmutableList.of("sudo apt-get -y install php5"));
-        if(resultOfCommand!=0)
-            log.warn("Installing problem installing php result {}", resultOfCommand);
+        if (resultOfCommand != 0)
+            log.warn("Problem installing php result {}", resultOfCommand);
         resultOfCommand = getMachine().execCommands("install php-mysql", ImmutableList.of("sudo apt-get -y install php5-mysql"));
-        if(resultOfCommand!=0)
-            log.warn("Installing problem installing php result {}", resultOfCommand);
+        if (resultOfCommand != 0)
+            log.warn("Problem installing php-mysql module result {}", resultOfCommand);
     }
 
     @Override

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheDriver.java
@@ -24,6 +24,4 @@ import brooklyn.entity.webapp.PhpWebAppDriver;
 public interface ApacheDriver extends PhpWebAppDriver {
 
 
-
-
 }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServer.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServer.java
@@ -28,14 +28,14 @@ import brooklyn.entity.trait.HasShortName;
 import brooklyn.entity.webapp.PhpWebAppService;
 import brooklyn.entity.webapp.PhpWebAppSoftwareProcess;
 import brooklyn.event.AttributeSensor;
-import brooklyn.event.basic.BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey;
 import brooklyn.event.basic.BasicAttributeSensorAndConfigKey;
+import brooklyn.event.basic.BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey;
 import brooklyn.event.basic.BasicConfigKey;
 import brooklyn.event.basic.PortAttributeSensorAndConfigKey;
 import brooklyn.event.basic.Sensors;
 import brooklyn.util.flags.SetFromFlag;
 
-@Catalog(name="HTTP Server", description="Apache HTTP Server Project is an open-source HTTP server")
+@Catalog(name = "HTTP Server", description = "Apache HTTP Server Project is an open-source HTTP server")
 @ImplementedBy(ApacheServerImpl.class)
 public interface ApacheServer extends PhpWebAppSoftwareProcess, PhpWebAppService, HasShortName {
 
@@ -75,7 +75,7 @@ public interface ApacheServer extends PhpWebAppSoftwareProcess, PhpWebAppService
             "apache.default.group", "default of Apache  to run the applications deployed in DEPLOY_RUN_DIR", "www-data");
 
     @SetFromFlag("http_port")
-    PortAttributeSensorAndConfigKey HTTP_PORT=
+    PortAttributeSensorAndConfigKey HTTP_PORT =
             new PortAttributeSensorAndConfigKey("apache.http.port", "Http port where Apache is listening", "80");
 
     @SetFromFlag("monitor_url")
@@ -87,37 +87,36 @@ public interface ApacheServer extends PhpWebAppSoftwareProcess, PhpWebAppService
             Sensors.newBooleanSensor("apache.monitor.up", "Monitor server is responding with OK");
 
     @SetFromFlag("total_accesses")
-    AttributeSensor<Long> TOTAL_ACCESSES=
+    AttributeSensor<Long> TOTAL_ACCESSES =
             Sensors.newLongSensor("apache.total.accesses", "Accesses to apache");
 
     @SetFromFlag("total_kbyte")
-    AttributeSensor<Long> TOTAL_KBYTE=
+    AttributeSensor<Long> TOTAL_KBYTE =
             Sensors.newLongSensor("apache.total.kbyte", "Total traffic in KB");
 
     @SetFromFlag("cpu_load")
-    AttributeSensor<Double> CPU_LOAD=
+    AttributeSensor<Double> CPU_LOAD =
             Sensors.newDoubleSensor("apache.cpu.load", "CPU load percent");
 
     @SetFromFlag("up_time")
-    AttributeSensor<Long> UP_TIME=
+    AttributeSensor<Long> UP_TIME =
             Sensors.newLongSensor("apache.up.time", "Time spent setting up the server");
 
     @SetFromFlag("request_per_sec")
-    AttributeSensor<Double> REQUEST_PER_SEC=
+    AttributeSensor<Double> REQUEST_PER_SEC =
             Sensors.newDoubleSensor("apache.request.per.sec", "Request per sec managed by the server");
 
     @SetFromFlag("bytes_per_sec")
-    AttributeSensor<Double> BYTES_PER_SEC=
+    AttributeSensor<Double> BYTES_PER_SEC =
             Sensors.newDoubleSensor("apache.bytes.per.sec", "Bytes per second");
 
     @SetFromFlag("bytes_per_req")
-    AttributeSensor<Double> BYTES_PER_REQ=
+    AttributeSensor<Double> BYTES_PER_REQ =
             Sensors.newDoubleSensor("apache.bytes.per.req", "Bytes per requests");
 
     @SetFromFlag("busy_workers")
-        AttributeSensor<Integer> BUSY_WORKERS=
+    AttributeSensor<Integer> BUSY_WORKERS =
             Sensors.newIntegerSensor("apache.busy.workers", "Number of busy worker");
-
 
 
 }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServerImpl.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServerImpl.java
@@ -107,6 +107,10 @@ public class ApacheServerImpl extends PhpWebAppSoftwareProcessImpl implements Ap
         return getConfig(DB_CONNECTION_CONFIG_PARAMS);
     }
 
+    public String getPhpVersion() {
+        return getConfig(SUGGESTED_PHP_VERSION);
+    }
+
 
     @Override
     public int getHttpPort() {

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServerImpl.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServerImpl.java
@@ -40,7 +40,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 
-public class ApacheServerImpl extends PhpWebAppSoftwareProcessImpl implements ApacheServer{
+public class ApacheServerImpl extends PhpWebAppSoftwareProcessImpl implements ApacheServer {
 
     public static final Logger log = LoggerFactory.getLogger(ApacheServerImpl.class);
 
@@ -49,11 +49,11 @@ public class ApacheServerImpl extends PhpWebAppSoftwareProcessImpl implements Ap
     private Enricher serviceUpEnricher;
 
 
-    public ApacheServerImpl(){
+    public ApacheServerImpl() {
         super();
     }
 
-    public ApacheServerImpl(Map flags){
+    public ApacheServerImpl(Map flags) {
         this(flags, null);
     }
 
@@ -71,45 +71,66 @@ public class ApacheServerImpl extends PhpWebAppSoftwareProcessImpl implements Ap
         return (ApacheDriver) super.getDriver();
     }
 
-    public String getDefaultGroup(){
+    public String getDefaultGroup() {
         return getConfig(DEFAULT_GROUP);
     }
 
-    public void setAppUser(String appName){
+    public void setAppUser(String appName) {
         setConfig(APP_NAME, appName);
     }
 
-    public String getInstallDir(){return getConfig(ApacheServer.INSTALL_DIR);}
+    public String getInstallDir() {
+        return getConfig(ApacheServer.INSTALL_DIR);
+    }
 
-    public String getConfigurationDir(){return getConfig(CONFIGURATION_DIR);}
+    public String getConfigurationDir() {
+        return getConfig(CONFIGURATION_DIR);
+    }
 
-    public String getAvailablesSitesConfigurationFile(){return getConfig(AVAILABLES_SITES_CONFIGURATION_FILE);}
+    public String getAvailablesSitesConfigurationFile() {
+        return getConfig(AVAILABLES_SITES_CONFIGURATION_FILE);
+    }
 
-    public String  getDeployRunDir(){ return getConfig(DEPLOY_RUN_DIR);}
+    public String getDeployRunDir() {
+        return getConfig(DEPLOY_RUN_DIR);
+    }
 
-    public String  getAvailableSitesConfigurationFolder(){ return getConfig(AVAILABLE_SITES_CONFIGURATION_FOLDER);}
+    public String getAvailableSitesConfigurationFolder() {
+        return getConfig(AVAILABLE_SITES_CONFIGURATION_FOLDER);
+    }
+
+    public String getDbConnectionFileConfig() {
+        return getConfig(DB_CONNECTION_FILE_CONFIG);
+    }
+
+    public Map<String, String> getDbConnectionConfigParams() {
+        return getConfig(DB_CONNECTION_CONFIG_PARAMS);
+    }
+
 
     @Override
-    public int getHttpPort(){ return getAttribute(ApacheServer.HTTP_PORT);}
+    public int getHttpPort() {
+        return getAttribute(ApacheServer.HTTP_PORT);
+    }
 
 
-    private Function<String,String> parseApacheStatus(final String key){
+    private Function<String, String> parseApacheStatus(final String key) {
         return new Function<String, String>() {
             @Nullable
             @Override
             public String apply(@Nullable String s) {
-                String result=null;
-                if((s!=null)&&(key!=null)&&(s.contains(key))){
-                    int i=s.indexOf(key)+key.length()+1;
-                    int j=s.indexOf("\n", i);
-                    result= s.substring(i, j).trim();
+                String result = null;
+                if ((s != null) && (key != null) && (s.contains(key))) {
+                    int i = s.indexOf(key) + key.length() + 1;
+                    int j = s.indexOf("\n", i);
+                    result = s.substring(i, j).trim();
                 }
                 return result;
             }
         };
     }
 
-    private <T>Function<String, T> cast(final Class<T> expected){
+    private <T> Function<String, T> cast(final Class<T> expected) {
         return new Function<String, T>() {
             @Nullable
             @Override
@@ -118,14 +139,11 @@ public class ApacheServerImpl extends PhpWebAppSoftwareProcessImpl implements Ap
                     return (T) null;
                 } else if (expected == long.class || expected == Long.class) {
                     return (T) (Long) Long.parseLong(s);
-                }
-                else if (expected == int.class || expected == Integer.class) {
+                } else if (expected == int.class || expected == Integer.class) {
                     return (T) (Integer) Integer.parseInt(s);
-                }
-                else if (expected == double.class || expected == Double.class) {
+                } else if (expected == double.class || expected == Double.class) {
                     return (T) (Double) Double.parseDouble(s);
-                }
-                else {
+                } else {
                     return (T) (String) s;
                 }
             }
@@ -136,19 +154,19 @@ public class ApacheServerImpl extends PhpWebAppSoftwareProcessImpl implements Ap
     protected void connectSensors() {
         super.connectSensors();
         functionFeed = FunctionFeed.builder()
-                    .entity(this)
-                    .poll(new FunctionPollConfig<Object, Boolean>(SERVICE_UP)
-                            .period(500, TimeUnit.MILLISECONDS)
-                            .callable(new Callable<Boolean>() {
-                                public Boolean call() throws Exception {
-                                    return getDriver().isRunning();
-                                }
-                            })
-                            .onException(Functions.constant(Boolean.FALSE)))
-                            .build();
+                .entity(this)
+                .poll(new FunctionPollConfig<Object, Boolean>(SERVICE_UP)
+                        .period(500, TimeUnit.MILLISECONDS)
+                        .callable(new Callable<Boolean>() {
+                            public Boolean call() throws Exception {
+                                return getDriver().isRunning();
+                            }
+                        })
+                        .onException(Functions.constant(Boolean.FALSE)))
+                .build();
 
         String monitorUri = String.format("http://%s:%s/%s",
-                getAttribute(Attributes.HOSTNAME),getHttpPort(),getConfig(MONITOR_URL));
+                getAttribute(Attributes.HOSTNAME), getHttpPort(), getConfig(MONITOR_URL));
         httpFeed = HttpFeed.builder()
                 .entity(this)
                 .period(200)
@@ -157,8 +175,8 @@ public class ApacheServerImpl extends PhpWebAppSoftwareProcessImpl implements Ap
                         .onSuccess(HttpValueFunctions.responseCodeEquals(200))
                         .onFailureOrException(Functions.constant(false)))
                 .poll(new HttpPollConfig<Long>(TOTAL_ACCESSES).onSuccess(
-                                Functionals.chain(HttpValueFunctions.stringContentsFunction(),
-                                        parseApacheStatus("Total Accesses"), cast(Long.class))))
+                        Functionals.chain(HttpValueFunctions.stringContentsFunction(),
+                                parseApacheStatus("Total Accesses"), cast(Long.class))))
                 .poll(new HttpPollConfig<Long>(TOTAL_KBYTE).onSuccess(
                         Functionals.chain(HttpValueFunctions.stringContentsFunction(),
                                 parseApacheStatus("Total kBytes"), cast(Long.class))))

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
@@ -71,6 +71,8 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
         return getEntity().getConfig(ApacheServer.DEPLOY_RUN_DIR);
     }
 
+
+
     @Override
     public void install() {
         super.install();
@@ -275,16 +277,40 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
         return result;
     }
 
+    //TODO refactos using the strategy pattern
     private String installPhp() {
-
-        String result = String.format(
-                "sudo apt-get -y install php5" +
-                "\n" +
-                "sudo apt-get -y install php5-mysql" +
-                "\n");
-        return result;
-
+        String result;
+        log.info("**PHP-VERSION:{}", new Object[]{getEntity().getPhpVersion()});
+        if(getEntity().getPhpVersion().equals("5.4")){
+            log.info("********************************");
+            log.info("*******------5.4-------*********");
+            log.info("********************************");
+            return instalPhp54v();
+        }
+        else {
+            return installPhpSuggestedVersionByDefault();
+        }
     }
+
+    private String instalPhp54v() {
+        String result = String.format(
+                "sudo add-apt-repository -y ppa:ondrej/php5-oldstable"+"\n" +
+                        "sudo apt-get update"+"\n"+
+                        "%s",
+                installPhpSuggestedVersionByDefault());
+        return result;
+    }
+
+
+    private String installPhpSuggestedVersionByDefault() {
+        String result = String.format(
+                "sudo apt-get -y install php5" + "\n" +
+                        "sudo apt-get -y install php5-mysql" + "\n");
+        return result;
+    }
+
+
+
 
     //TODO
     @Override
@@ -396,5 +422,4 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
     private String scapeString(String s) {
         return s.replace("/", "\\/");
     }
-
 }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
@@ -23,16 +23,19 @@ import brooklyn.entity.webapp.PhpWebAppSshDriver;
 import brooklyn.location.basic.SshMachineLocation;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.ssh.BashCommands;
+import brooklyn.util.text.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver {
@@ -59,20 +62,20 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
     }
 
     @Override
-    public Integer getHttpPort(){
+    public Integer getHttpPort() {
         return getEntity().getHttpPort();
     }
 
     @Override
-    public String getRunDir(){
+    public String getRunDir() {
         return getEntity().getConfig(ApacheServer.DEPLOY_RUN_DIR);
     }
 
     @Override
-    public void install(){
+    public void install() {
         super.install();
-        if(!isApacheInstalled()){
-            LOG.info("Apache is not installing, so install in {}", new Object[]{this});
+        if (!isApacheInstalled()) {
+            LOG.info("Apache is not installing, then it will be installed in {}", new Object[]{this});
             /*Maybe, we find a old apache configuration file which have to be removed to install the new
             * server without errors.*/
             removeOldConfigFile();
@@ -80,34 +83,34 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
         }
     }
 
-    private boolean isApacheInstalled(){
-        boolean apacheIsInstalled=false;
-        int result= getMachine().execCommands("apacheInstalled", ImmutableList.of("apache2 -v"));
-        if (result==0)
-            apacheIsInstalled=true;
+    private boolean isApacheInstalled() {
+        boolean apacheIsInstalled = false;
+        int result = getMachine().execCommands("apacheInstalled", ImmutableList.of("apache2 -v"));
+        if (result == 0)
+            apacheIsInstalled = true;
         return apacheIsInstalled;
     }
 
-    private void removeOldConfigFile(){
-        String oldApacheConfigurationFilePath=getEntity().getConfigurationDir()+"/"+"apache2.conf";
-        getMachine().execCommands("deleteOldApacheConfigFile", ImmutableList.of("rm -f"+oldApacheConfigurationFilePath));
+    private void removeOldConfigFile() {
+        String oldApacheConfigurationFilePath = getEntity().getConfigurationDir() + "/" + "apache2.conf";
+        getMachine().execCommands("deleteOldApacheConfigFile", ImmutableList.of("rm -f" + oldApacheConfigurationFilePath));
     }
 
-    private int installApacheServer(){
+    private int installApacheServer() {
         int result;
         LOG.info("Installing Apache Server {}", new Object[]{getEntity()});
-        List<String> commands= ImmutableList.<String>builder().add(BashCommands.
+        List<String> commands = ImmutableList.<String>builder().add(BashCommands.
                 installPackage(MutableMap.of("apt", "apache2"), null)).build();
-        result=newScript(INSTALLING).body.append(commands).execute();
-        if(result!=0)
-            log.warn("Problem installing {} for {}: result {}", new Object[]{ entity, result});
+        result = newScript(INSTALLING).body.append(commands).execute();
+        if (result != 0)
+            log.warn("Problem installing {} for {}: result {}", new Object[]{entity, result});
         else
-            log.info("Installed {} for {} commands {}\n", new Object[]{ result, entity, commands});
+            log.info("Installed {} for {} commands {}\n", new Object[]{result, entity, commands});
         return result;
     }
 
     @Override
-    public void customize(){
+    public void customize() {
         startApacheIfIsNotRunning();
         newScript(CUSTOMIZING)
                 .body.append(
@@ -118,22 +121,23 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
                 enableServerStatusServerModule(),
                 configureHttpPort(),
                 realoadApacheService(),
-                installPhp()
+                installPhp(),
+                realoadApacheService()
         ).execute();
-        LOG.info("deployInit initial applications from {}", new Object[]{this});
+        LOG.info("DeployInit initial applications from {}", new Object[]{this});
         getEntity().deployInitialApplications();
     }
 
-    private void startApacheIfIsNotRunning(){
-        if(!isRunning())
+    private void startApacheIfIsNotRunning() {
+        if (!isRunning())
             startApache();
     }
 
-    private int startApache(){
-        return  getMachine().execCommands("startApacheIfItIsNeeded", ImmutableList.of("service apache2 start"));
+    private int startApache() {
+        return getMachine().execCommands("startApacheIfItIsNeeded", ImmutableList.of("service apache2 start"));
     }
 
-    private String disableCurrentDeployRunDir(){
+    private String disableCurrentDeployRunDir() {
 
         String result = String.format(
                 "for file in %s%s/*.conf\n" +
@@ -147,31 +151,32 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
                 getEntity().getConfigurationDir(),
                 getEntity().getAvailableSitesConfigurationFolder(),
                 getEntity().getConfigurationDir());
+        ;
         return result;
     }
 
-    private String realoadApacheService(){
+    private String realoadApacheService() {
         return "set +e\n" +
                 "invoke-rc.d apache2 reload\n";
     }
 
-    private String removeAvailableSitesConfigurationFolder(){
-        String result=String.format(
+    private String removeAvailableSitesConfigurationFolder() {
+        String result = String.format(
                 "rm -rf %s%s/*\n",
                 getEntity().getConfigurationDir(),
                 getEntity().getAvailableSitesConfigurationFolder());
         return result;
     }
 
-    private String  addFolderToAvailablesSitesConfigurationFile(String targetName){
-        String result= String.format(
+    private String addFolderToAvailablesSitesConfigurationFile(String targetName) {
+        String result = String.format(
                 "cat <<EOT >> %s%s/%s\n" +
-                        "#"+targetName+"\n"+
+                        "#" + targetName + "\n" +
                         "<VirtualHost *:%s>\n" +
                         "\tServerAdmin webmaster@localhost\n" +
-                        "\tDocumentRoot %s/"+targetName+"\n"+
-                        "\tErrorLog ${APACHE_LOG_DIR}/error-"+targetName+".log\n" +
-                        "\tCustomLog ${APACHE_LOG_DIR}/access-"+targetName+".log combined\n" +
+                        "\tDocumentRoot %s/" + targetName + "\n" +
+                        "\tErrorLog ${APACHE_LOG_DIR}/error-" + targetName + ".log\n" +
+                        "\tCustomLog ${APACHE_LOG_DIR}/access-" + targetName + ".log combined\n" +
                         "</VirtualHost>\n" +
                         "EOT",
                 getEntity().getConfigurationDir(),
@@ -179,21 +184,21 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
                 getEntity().getAvailablesSitesConfigurationFile(),
                 getEntity().getHttpPort(),
                 getEntity().getDeployRunDir(),
-                changePermissionsOfFolder(getEntity().getDeployRunDir()+"/"+targetName));
+                changePermissionsOfFolder(getEntity().getDeployRunDir() + "/" + targetName));
         return result;
     }
 
-    private String createDeployRunDirConfigurationFile(){
-        String result= String.format(
-                "%s\n"+
+    private String createDeployRunDirConfigurationFile() {
+        String result = String.format(
+                "%s\n" +
                         "cat > %s%s/%s << \"EOF\"\n" +
                         "#[Brooklyn] Configuration File\n" +
                         "#app_id\n" +
                         "#<VirtualHost * :${PORT}>\n" +
                         "\t#ServerAdmin webmaster@localhost\n" +
-                        "\t#DocumentRoot ${DEPLOY_RUN_DIR}/app_id\n"+
-                        "\t#ErrorLog ${APACHE_LOG_DIR} /error-app_id.log\n"+
-                        "\t#ErrorLog ${APACHE_LOG_DIR} /access-app_id.log combined\n"+
+                        "\t#DocumentRoot ${DEPLOY_RUN_DIR}/app_id\n" +
+                        "\t#ErrorLog ${APACHE_LOG_DIR} /error-app_id.log\n" +
+                        "\t#ErrorLog ${APACHE_LOG_DIR} /access-app_id.log combined\n" +
                         "\n\n\t#SSL_CONFIGURATION\n" +
                         "\t# SSL SETUP\n" +
                         "\t# ServerName www.awesomesite.com/app_id\n" +
@@ -218,15 +223,15 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
         return result;
     }
 
-    private String createFolderDeployRunDir(){
-        return "mkdir -p "+getRunDir()+"\n";
+    private String createFolderDeployRunDir() {
+        return "mkdir -p " + getRunDir() + "\n";
     }
 
-    private String changePermissionsOfFolder(String folder){
-        return String.format("chown -R %s:%s %s\n",getEntity().getDefaultGroup(), getEntity().getDefaultGroup(),folder);
+    private String changePermissionsOfFolder(String folder) {
+        return String.format("chown -R %s:%s %s\n", getEntity().getDefaultGroup(), getEntity().getDefaultGroup(), folder);
     }
 
-    private String enableAvailableDeploymentRunDir(){
+    private String enableAvailableDeploymentRunDir() {
         String result = String.format(
                 "for file in %s%s/*.conf\n" +
                         "do\n" +
@@ -240,18 +245,19 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
         return result;
     }
 
-    private String enableServerStatusServerModule(){
+    private String enableServerStatusServerModule() {
         String result;
-        result= String.format(
+        result = String.format(
                 "cat <<EOT >> %s/apache2.conf\n" +
                         "<Location /server-status>\n" +
                         "\tSetHandler server-status\n" +
                         "\tOrder deny,allow\n" +
-                        "\tDeny from all\n" +
-                        "\tAllow from localhost\n" +
-                        "\tAllow from %s\n" +
+                        "\t#Deny from all\n" +
+                        "\t#Allow from localhost\n" +
+                        "\t#Allow from %s\n" +
+                        "\tAllow from all\n" +
                         "</Location>\n" +
-                        "ExtendedStatus On\n"+
+                        "ExtendedStatus On\n" +
                         "EOT\n",
                 getEntity().getConfigurationDir(),
                 getBrooklynIPv4());
@@ -259,9 +265,9 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
     }
 
     //TODO the port configuration could be modified. So it is needed find Listen and change the port
-    private String configureHttpPort(){
+    private String configureHttpPort() {
         String result;
-        result= String.format(
+        result = String.format(
                 "sed -i 's@Listen[ 0-9]\\+@Listen %s@g' %s/ports.conf",
                 getEntity().getHttpPort(),
                 getEntity().getConfigurationDir()
@@ -269,11 +275,13 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
         return result;
     }
 
-    private String installPhp(){
+    private String installPhp() {
 
         String result = String.format(
                 "sudo apt-get -y install php5" +
-                        "\n");
+                "\n" +
+                "sudo apt-get -y install php5-mysql" +
+                "\n");
         return result;
 
     }
@@ -286,19 +294,19 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
     }
 
     @Override
-    public String deployGitResource(String url, String targetName){
+    public String deployGitResource(String url, String targetName) {
         super.deployGitResource(url, targetName);
         newScript(CUSTOMIZING)
                 .body.append(
                 addFolderToAvailablesSitesConfigurationFile(targetName),
                 realoadApacheService(),
                 enableAvailableDeploymentRunDir()).execute();
-
+        stablishDBConnectionstablishDBConnection(getEntity().getDeployRunDir() + "/" + targetName);
         return targetName;
     }
 
     @Override
-    public String deployTarballResource(String url, String targetName){
+    public String deployTarballResource(String url, String targetName) {
         super.deployTarballResource(url, targetName);
         newScript(CUSTOMIZING)
                 .body.append(
@@ -311,25 +319,22 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
 
     @Override
     public boolean isRunning() {
-        boolean isApacheRunning=false;
+        boolean isApacheRunning = false;
         //int resultOfCommand = getMachine().execCommands("apacheIsRunning", ImmutableList.of("service apache2 status"));
-        String command="service apache2 status";
-        int resultOfCommand=newScript(STOPPING)
+        String command = "service apache2 status";
+        int resultOfCommand = newScript(STOPPING)
                 .body.append(command).execute();
-        if (resultOfCommand==0)
-            isApacheRunning=true;
-        return  isApacheRunning;
+        if (resultOfCommand == 0)
+            isApacheRunning = true;
+        return isApacheRunning;
     }
-
 
     //TODO merge with the stopApacheMethod in any way
     @Override
     public void stop() {
-
-        String command="service apache2 stop";
+        String command = "service apache2 stop";
         newScript(STOPPING)
                 .body.append(command).execute();
-
     }
 
     @Override
@@ -338,7 +343,6 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
     }
 
     private String getBrooklynIPv4() {
-
         String ip = "127.0.0.1";
         try {
             Enumeration<NetworkInterface> n = NetworkInterface.getNetworkInterfaces();
@@ -360,5 +364,37 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
         }
         return ip;
     }
-}
 
+    private void stablishDBConnectionstablishDBConnection(String targetNameApplication) {
+        String configurationDBFilePath;
+        if (!Strings.isEmpty(getEntity().getDbConnectionFileConfig())) {
+            configurationDBFilePath = targetNameApplication + "/" + getEntity().getDbConnectionFileConfig();
+            configureDatabaseFile(configurationDBFilePath);
+        }
+    }
+
+    private void configureDatabaseFile(String pathFile) {
+        Map<String, String> databaseParameters = getEntity().getDbConnectionConfigParams();
+        String command;
+        Set<String> configurationParameters;
+        if (databaseParameters != null) {
+            configurationParameters = databaseParameters.keySet();
+            log.info("DATABASE-Command!! Path {} ", new Object[]{pathFile});
+            log.info("DATABASE-Command!! Number Keys {} ", new Object[]{configurationParameters.size()});
+            for (String configurationParameter : configurationParameters) {
+                command = String.format(
+                        "sed -i 's/define([ ]*'\\''%s'\\''[ ]*,[ ]*'\\''[ a-zA-Z0-9'.']*'\\''[ ]*);/define('\\''%s'\\'' , '\\''%s'\\'');/g' %s",
+                        configurationParameter, configurationParameter, scapeString(databaseParameters.get(configurationParameter)), pathFile);
+                log.info("DATABASE-Command!!:: " + command);
+                getMachine().execCommands("configParamDatabaseConnection", ImmutableList.of(command));
+            }
+//            Collection<String> st = getEntity().phpSys();
+
+        }
+    }
+
+    private String scapeString(String s) {
+        return s.replace("/", "\\/");
+    }
+
+}


### PR DESCRIPTION
Remote support was added for php applications. Older versions work only in localhost.

Database configuration parameters were added to YAML. Below, we can see a php deployment example using a git repo and how the given parameters for configuring a database connection.

``` yaml
- serviceType: brooklyn.entity.webapp.apache.ApacheServer
  name: Apache Server
  location: aws-ec2:us-west-2
  brooklyn.config:
    http_port: 80
    app_git_repo_url: https://seaclDem:seaclouds@bitbucket.org/seaclDem/nurocasestudyphp5-5.git    
    db_connection_file_config: config/config.php
    db_connection_config_params:
      g_DatabaseHost: $brooklyn:formatString("%s", component("db").attributeWhenReady("host.address"))
      g_DatabasePort: $brooklyn:component("db").attributeWhenReady("mysql.port")
      g_DatabasePassword: br00k11n
      g_DatabaseUser: brooklyn
```

The parameter `db_connection_file_config` specifies the configuration file inside php application which contains the necessary parameters to establish the connection with the database. 
This file should be contains a sentence like the next one for each necessary parameter:

``` php
define( %parameterID, %value);
```

Below, we can see a list of parameters definition for a database connection. In this case, we have given a default configuration using general values. As soon as the parameters contains expected values by the database, the connection will be establish.

``` php
define( 'g_DatabaseHost', '127.0.0.1'); #database host ip
define( 'g_DatabasePort', '3306'); #port
define( 'g_DatabaseName', 'database1'); #name of the database
define( 'g_DatabaseUser', 'seaclouds'); #allowed user for the database
define( 'g_DatabasePassword', 'seaklouds'); #database password
```

However,  this values could depend of the runtime values, e.g. the  database host ip could be known when the database host is deployed. So, the configuration by default it is not always correct.

The required parameters showed before are configured using  `db_connection_config_params`. It is a map what define the values for each parameter defined in the file pointed by `db_connection_file_config`. Then the above yaml example will modify the `config/config.php` in the next way:

``` php
define( 'g_DatabaseHost', %depend-of-the-database-host); #database host ip
define( 'g_DatabasePort', %depend-of-the-database-server); #port
define( 'g_DatabaseName', 'database1'); #name of the database
define( 'g_DatabaseUser', 'seaclouds'); #allowed user for the database
define( 'g_DatabasePassword', 'seaklouds'); #database password
```

The php application should understand these parameters for connecting with the database.
