### PR TITLE
Adding PHP Version Description to log and console

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessSshDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessSshDriver.java
@@ -818,7 +818,7 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
     public int copyUsingProtocol(String url, String deployTargetDir){
         int result =0;
         if(isHttpsGitURL(url)){
-            log.info("Git: it is a git repo {} {}", new Object[]{this, url});
+            log.info("The URL it is a git repository: {}", new Object[]{url});
             result = copyUsingProtocolGitHttps(url, deployTargetDir);
         }
         return result;
@@ -826,7 +826,7 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
 
     private  boolean isHttpsGitURL(String url){
         boolean isHttpsGitURL;
-        if(Strings.isNonBlank(url)) {
+        if(Strings.isBlank(url)) {
             log.info("git URL is null.");
         }
         isHttpsGitURL=checkGitExtension(url)&&checkHttpsPrefix(url);

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppService.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppService.java
@@ -62,9 +62,9 @@ public interface PhpWebAppService extends WebAppService {
     public static final MapConfigKey<String> DB_CONNECTION_CONFIG_PARAMS = new MapConfigKey<String>(String.class,
             "php.db.connection.config.params", "PHP application file to start e.g. main.php, or launch.php");
 
-
     @SetFromFlag("php.version")
-    public static final ConfigKey<String> SUGGESTED_PHP_VERSION =
-            ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.5.9");
+    public static final ConfigKey<String> SUGGESTED_PHP_VERSION = ConfigKeys.newStringConfigKey(
+            "php.version", "PHP version used", "5.5.9");
+
 
 }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSshDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSshDriver.java
@@ -123,7 +123,7 @@ public abstract class PhpWebAppSshDriver extends AbstractSoftwareProcessSshDrive
 
     @Override
     public String deployGitResource(String url, String targetName) {
-        log.info("{} deploying Git Resource{} to {}:{}", new Object[]{entity, url, getHostname()});
+        log.info("{} deploying Git Resource {} to {}:{}", new Object[]{entity, url, getHostname()});
         String deployTargetDir = getDeployDir() + targetName;
         int copyResult = copyUsingProtocol(url, deployTargetDir);
         if (copyResult != 0)
@@ -173,19 +173,16 @@ public abstract class PhpWebAppSshDriver extends AbstractSoftwareProcessSshDrive
     @Override
     public void install() {
         //Fixme use the newScript to install php
-//        List<String> commands = ImmutableList.<String>builder()
-//                .add(BashCommands.installPackage(MutableMap.of("apt", "php5"), null))
-//                .build();
-//        log.info("Installing php5 {}", new Object[]{this});
-//        newScript(INSTALLING)
-//                .body.append(commands)
-//                .execute();
+
         int resultOfCommand = getMachine().execCommands("install php", ImmutableList.of("sudo apt-get -y install php5"));
-        if (resultOfCommand != 0)
+        if (resultOfCommand != 0) {
             log.warn("Problem installing php result {}", resultOfCommand);
+        }
+
         resultOfCommand = getMachine().execCommands("install php-mysql", ImmutableList.of("sudo apt-get -y install php5-mysql"));
-        if (resultOfCommand != 0)
+        if (resultOfCommand != 0) {
             log.warn("Problem installing php-mysql module result {}", resultOfCommand);
+        }
     }
 
     @Override

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
@@ -402,13 +402,13 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
         Set<String> configurationParameters;
         if (databaseParameters != null) {
             configurationParameters = databaseParameters.keySet();
-            log.info("DATABASE-Command!! Path {} ", new Object[]{pathFile});
-            log.info("DATABASE-Command!! Number Keys {} ", new Object[]{configurationParameters.size()});
+            log.debug("DATABASE-Command!! Path {} ", new Object[]{pathFile});
+            log.debug("DATABASE-Command!! Number Keys {} ", new Object[]{configurationParameters.size()});
             for (String configurationParameter : configurationParameters) {
                 command = String.format(
                         "sed -i 's/define([ ]*'\\''%s'\\''[ ]*,[ ]*'\\''[ a-zA-Z0-9'.']*'\\''[ ]*);/define('\\''%s'\\'' , '\\''%s'\\'');/g' %s",
                         configurationParameter, configurationParameter, scapeString(databaseParameters.get(configurationParameter)), pathFile);
-                log.info("DATABASE-Command!!:: " + command);
+                log.debug("DATABASE-Command-Param-Configuration!!:: " + command);
                 getMachine().execCommands("configParamDatabaseConnection", ImmutableList.of(command));
             }
 //            Collection<String> st = getEntity().phpSys();

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
@@ -281,10 +281,7 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
     private String installPhp() {
         String result;
         log.info("**PHP-VERSION:{}", new Object[]{getEntity().getPhpVersion()});
-        if(getEntity().getPhpVersion().equals("5.4")){
-            log.info("********************************");
-            log.info("*******------5.4-------*********");
-            log.info("********************************");
+        if(getEntity().getPhpVersion().equals("5.4")){;
             return instalPhp54v();
         }
         else {


### PR DESCRIPTION
The PHP version selection is enabled.
The PHP version description is showed in the logs and console.

Below, we can see a php deployment example which specifies the required target PHP version through `php.version`.

``` yaml
name: PHP-DB-Brooklyn-Dsktp-54
services:
- serviceType: brooklyn.entity.webapp.apache.ApacheServer
  name: Apache Server
  location: aws-ec2:us-west-2
  php.version: 5.4
  brooklyn.config:
    http_port: 80
    app_git_repo_url: https://seaclDem:seaclouds@bitbucket.org/seaclDem/nurocasestudyphp5-4.git   
    db_connection_file_config: config/config.php
    db_connection_config_params:
      g_DatabaseHost: $brooklyn:formatString("%s", component("db").attributeWhenReady("host.address"))
      g_DatabaseName: database1
      g_DatabasePassword: br00k11n
      g_DatabaseUser: brooklyn
```
