### PR TITLE
Fixed an infinite loop after calling stop or expunge on PHP entities. 

### DIFF
--- a/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSoftwareProcessImpl.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/PhpWebAppSoftwareProcessImpl.java
@@ -82,13 +82,13 @@ public abstract class PhpWebAppSoftwareProcessImpl extends SoftwareProcessImpl i
 
     @Override
     protected void preStop(){
+        super.preStop();
         //zero our workrate derived workrates.
         //TODO might not be enough, as a policy may still be executing and have a record of historic vals;
         // should remove policies
         // also nor sure we want this; implies more generally a resposibility for sensor to announce things
         // disconnected
         putEnricherValuesToNullValue();
-        super.doStop();
     }
 
     private void putEnricherValuesToNullValue() {

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheSshDriver.java
@@ -362,7 +362,7 @@ public class ApacheSshDriver extends PhpWebAppSshDriver implements ApacheDriver 
 
     @Override
     public void kill() {
-        stop();
+        newScript(KILLING).execute();
     }
 
     private String getBrooklynIPv4() {


### PR DESCRIPTION
The stop operation of the PHP entity was fixed.
Before, Brooklyn found a error when the user stopped or expunged an application.
