### PR TITLE
PHP sensors are connected to WebApp Sensors.

### DIFF
--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServer.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServer.java
@@ -86,7 +86,7 @@ public interface ApacheServer extends PhpWebAppSoftwareProcess, PhpWebAppService
     AttributeSensor<Boolean> MONITOR_URL_UP =
             Sensors.newBooleanSensor("webapp.monitor.up", "Monitor server is responding with OK");
 
-    @SetFromFlag("total_byte")
+    @SetFromFlag("total_kbyte")
     AttributeSensor<Long> TOTAL_KBYTE =
             Sensors.newLongSensor("webapp.total.kbyte", "Total server traffic in kbytes");
 

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServer.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServer.java
@@ -84,39 +84,32 @@ public interface ApacheServer extends PhpWebAppSoftwareProcess, PhpWebAppService
 
     @SetFromFlag("monitor_url_up")
     AttributeSensor<Boolean> MONITOR_URL_UP =
-            Sensors.newBooleanSensor("apache.monitor.up", "Monitor server is responding with OK");
+            Sensors.newBooleanSensor("webapp.monitor.up", "Monitor server is responding with OK");
 
-    @SetFromFlag("total_accesses")
-    AttributeSensor<Long> TOTAL_ACCESSES =
-            Sensors.newLongSensor("apache.total.accesses", "Accesses to apache");
-
-    @SetFromFlag("total_kbyte")
+    @SetFromFlag("total_byte")
     AttributeSensor<Long> TOTAL_KBYTE =
-            Sensors.newLongSensor("apache.total.kbyte", "Total traffic in KB");
+            Sensors.newLongSensor("webapp.total.kbyte", "Total server traffic in kbytes");
 
     @SetFromFlag("cpu_load")
     AttributeSensor<Double> CPU_LOAD =
-            Sensors.newDoubleSensor("apache.cpu.load", "CPU load percent");
+            Sensors.newDoubleSensor("webapp.cpu.load", "CPU load percent");
 
-    @SetFromFlag("up_time")
-    AttributeSensor<Long> UP_TIME =
-            Sensors.newLongSensor("apache.up.time", "Time spent setting up the server");
 
     @SetFromFlag("request_per_sec")
     AttributeSensor<Double> REQUEST_PER_SEC =
-            Sensors.newDoubleSensor("apache.request.per.sec", "Request per sec managed by the server");
+            Sensors.newDoubleSensor("webapp.request.per.sec", "Request per sec managed by the server");
 
     @SetFromFlag("bytes_per_sec")
     AttributeSensor<Double> BYTES_PER_SEC =
-            Sensors.newDoubleSensor("apache.bytes.per.sec", "Bytes per second");
+            Sensors.newDoubleSensor("webapp.bytes.per.sec", "Bytes per second");
 
     @SetFromFlag("bytes_per_req")
     AttributeSensor<Double> BYTES_PER_REQ =
-            Sensors.newDoubleSensor("apache.bytes.per.req", "Bytes per requests");
+            Sensors.newDoubleSensor("webapp.bytes.per.req", "Bytes per requests");
 
     @SetFromFlag("busy_workers")
     AttributeSensor<Integer> BUSY_WORKERS =
-            Sensors.newIntegerSensor("apache.busy.workers", "Number of busy worker");
+            Sensors.newIntegerSensor("webapp.busy.workers", "Number of busy worker");
 
 
 }

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServerImpl.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/apache/ApacheServerImpl.java
@@ -19,6 +19,7 @@
 package brooklyn.entity.webapp.apache;
 
 
+import brooklyn.enricher.Enrichers;
 import brooklyn.entity.Entity;
 import brooklyn.entity.basic.Attributes;
 import brooklyn.entity.webapp.PhpWebAppSoftwareProcessImpl;
@@ -29,6 +30,8 @@ import brooklyn.event.feed.http.HttpPollConfig;
 import brooklyn.event.feed.http.HttpValueFunctions;
 import brooklyn.policy.Enricher;
 import brooklyn.util.guava.Functionals;
+import brooklyn.event.Sensor;
+
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import org.slf4j.Logger;
@@ -36,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -178,18 +182,18 @@ public class ApacheServerImpl extends PhpWebAppSoftwareProcessImpl implements Ap
                 .poll(new HttpPollConfig<Boolean>(MONITOR_URL_UP)
                         .onSuccess(HttpValueFunctions.responseCodeEquals(200))
                         .onFailureOrException(Functions.constant(false)))
-                .poll(new HttpPollConfig<Long>(TOTAL_ACCESSES).onSuccess(
+                .poll(new HttpPollConfig<Integer>(REQUEST_COUNT).onSuccess(
                         Functionals.chain(HttpValueFunctions.stringContentsFunction(),
-                                parseApacheStatus("Total Accesses"), cast(Long.class))))
+                                parseApacheStatus("Total Accesses"), cast(Integer.class))) )
                 .poll(new HttpPollConfig<Long>(TOTAL_KBYTE).onSuccess(
                         Functionals.chain(HttpValueFunctions.stringContentsFunction(),
                                 parseApacheStatus("Total kBytes"), cast(Long.class))))
                 .poll(new HttpPollConfig<Double>(CPU_LOAD).onSuccess(
                         Functionals.chain(HttpValueFunctions.stringContentsFunction(),
                                 parseApacheStatus("CPULoad"), cast(Double.class))))
-                .poll(new HttpPollConfig<Long>(UP_TIME).onSuccess(
+                .poll(new HttpPollConfig<Integer>(TOTAL_PROCESSING_TIME).onSuccess(
                         Functionals.chain(HttpValueFunctions.stringContentsFunction(),
-                                parseApacheStatus("Uptime"), cast(Long.class))))
+                                parseApacheStatus("Uptime"), cast(Integer.class))))
                 .poll(new HttpPollConfig<Double>(REQUEST_PER_SEC).onSuccess(
                         Functionals.chain(HttpValueFunctions.stringContentsFunction(),
                                 parseApacheStatus("ReqPerSec"), cast(Double.class))))


### PR DESCRIPTION
The Apache sensors are renamed to `webapp` to maintain
the same name sensor.
A operation enricher are included in order to deduce values
among several sensors.

Some `web.app.*` sensors can not be connected to Apache Server:

```
webapp.reqs.bytes.received
webapp.reqs.bytes.sent
webapp.reqs.processingTime.max
webapp.reqs.processingTime.max
```
